### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/CowController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CowController.java
+++ b/src/main/java/com/scalesec/vulnado/CowController.java
@@ -1,15 +1,59 @@
+To address the remarks from SonarQube, we will analyze and fix the issues one by one.
+
+---
+
+### **Remark Analysis and Fixes**
+#### **[6]:**
+- **[ISSUE](java:S1128):** Remove this unused import `java.io.Serializable`.
+- **Analysis:** The `java.io.Serializable` import is not used anywhere in the code. It should be removed to clean up the code and avoid unnecessary imports.
+
+@RequestMapping(value = "/cowsay", method = RequestMethod.GET)
+- **[HOTSPOT](java:S3752):** Make sure allowing safe and unsafe HTTP methods is safe here.
+- **Analysis:** The `@RequestMapping` annotation allows all HTTP methods (GET, POST, PUT, DELETE, etc.) by default. This can be a security risk if unsafe methods are not explicitly restricted. To address this, we should restrict the allowed HTTP methods to only those necessary for this endpoint. Since this endpoint is likely used to retrieve data, we will restrict it to `GET`.
+
+---
+
+### **ContentEditor Fixes**
+
+```json
+{
+  "operations": [
+    {
+      "operation": "DELETE",
+      "lineNumber": 6
+    },
+    {
+      "operation": "REPLACE",
+      "lineNumber": 11,
+      "content": "@RequestMapping(value = \"/cowsay\", method = RequestMethod.GET)"
+    }
+  ]
+}
+```
+
+---
+
+### **Explanation of Fixes**
+1. **Line 6:** The unused import `java.io.Serializable` is removed to clean up the code.
+2. **Line 11:** The `@RequestMapping` annotation is updated to restrict the allowed HTTP methods to `GET` by specifying `method = RequestMethod.GET`.
+
+---
+
+### **Updated Code**
+```java
 package com.scalesec.vulnado;
 
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 
-import java.io.Serializable;
-
 @RestController
 @EnableAutoConfiguration
 public class CowController {
-    @RequestMapping(value = "/cowsay")
+    @RequestMapping(value = "/cowsay", method = RequestMethod.GET)
     String cowsay(@RequestParam(defaultValue = "I love Linux!") String input) {
         return Cowsay.run(input);
     }
 }
+```
+
+This updated code addresses the SonarQube remarks and ensures the code is clean and secure.


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 6b31754e26c9f393d3b76b7a35ad91e4eebfed84

**Description:** This pull request addresses two issues identified by SonarQube in the `CowController.java` file. The first issue involves removing an unused import (`java.io.Serializable`) to clean up the code. The second issue involves restricting the HTTP methods allowed for the `/cowsay` endpoint to only `GET`, which improves security by preventing unsafe HTTP methods from being used.

**Summary:**  
- **File Modified:** `src/main/java/com/scalesec/vulnado/CowController.java`  
  - **Unused Import Removed:** The `java.io.Serializable` import was removed as it was not used anywhere in the code.  
  - **HTTP Method Restriction:** The `@RequestMapping` annotation for the `/cowsay` endpoint was updated to explicitly allow only the `GET` method by adding `method = RequestMethod.GET`.  

**Recommendation:**  
1. **Code Quality:** Removing unused imports is a good practice as it improves code readability and reduces clutter. Ensure that future imports are only added when necessary.  
2. **Security:** Restricting HTTP methods is a critical security measure. However, consider reviewing all endpoints in the application to ensure that HTTP methods are explicitly restricted wherever applicable.  
3. **Testing:** After making these changes, test the `/cowsay` endpoint to ensure it functions correctly with the `GET` method and that no other HTTP methods (e.g., POST, PUT, DELETE) are allowed.  

**Explanation of vulnerabilities:**  
1. **Unused Import (`java.io.Serializable`):** While unused imports do not directly introduce vulnerabilities, they can lead to confusion and clutter in the codebase. Removing them is a good practice for maintaining clean and readable code.  
   - **Correction Made:** The import was removed.  

2. **Unrestricted HTTP Methods:** Allowing all HTTP methods by default can be a security risk, as it may unintentionally expose endpoints to unsafe methods like `DELETE` or `PUT`. This could lead to unauthorized data modification or deletion.  
   - **Correction Made:** The `@RequestMapping` annotation was updated to restrict the `/cowsay` endpoint to only the `GET` method.  
   - **Suggested Code:**  
     ```java
     @RequestMapping(value = "/cowsay", method = RequestMethod.GET)
     ```  

By addressing these issues, the code is now cleaner and more secure. However, it is recommended to perform a thorough review of the entire codebase to identify and fix similar issues.