### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,23 +1,96 @@
+To address the remarks provided by SonarQube, we will analyze and fix each issue step by step. Below are the changes required:
+
+### [3]: Remove unused import `org.springframework.boot.*`
+The import `org.springframework.boot.*` is not used in the code and should be removed.
+
+
+### [4]: Remove unused import `org.springframework.http.HttpStatus`
+The import `org.springframework.http.HttpStatus` is not used in the code and should be removed.
+
+---
+
+@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
+The import `java.io.Serializable` is not used in the code and should be removed.
+
+---
+@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
+### [15] and [19]: Ensure safe handling of HTTP methods
+The remarks suggest verifying the safety of allowing both safe and unsafe HTTP methods. Since the code uses `@RequestMapping`, which allows all HTTP methods by default, we should restrict it to safe methods (e.g., `GET`) explicitly.
+
+---
+
+### ContentEditor Changes
+
+Here are the changes applied using the `ContentEditor`:
+
+```json
+{
+  "operations": [
+    {
+      "operation": "DELETE",
+      "lineNumber": 3
+    },
+    {
+      "operation": "DELETE",
+      "lineNumber": 4
+    },
+    {
+      "operation": "DELETE",
+      "lineNumber": 8
+    },
+    {
+      "operation": "REPLACE",
+      "lineNumber": 15,
+      "content": "@RequestMapping(value = \"/links\", produces = \"application/json\", method = RequestMethod.GET)"
+    },
+    {
+      "operation": "REPLACE",
+      "lineNumber": 19,
+      "content": "@RequestMapping(value = \"/links-v2\", produces = \"application/json\", method = RequestMethod.GET)"
+    }
+  ]
+}
+```
+
+---
+
+### Explanation of Changes
+
+1. **Unused Imports**:
+   - Removed the unused imports `org.springframework.boot.*`, `org.springframework.http.HttpStatus`, and `java.io.Serializable` to clean up the code and improve readability.
+
+2. **Restrict HTTP Methods**:
+   - Updated the `@RequestMapping` annotations on lines 15 and 19 to explicitly allow only the `GET` method. This ensures that unsafe HTTP methods (e.g., `POST`, `PUT`, `DELETE`) are not allowed, addressing the security hotspot.
+
+---
+
+### Final Code After Changes
+
+```java
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
+  List<String> links(@RequestParam String url) throws IOException {
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
+
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
+  List<String> linksV2(@RequestParam String url) throws BadRequest {
     return LinkLister.getLinksV2(url);
   }
 }
+```
+
+---
+
+### Summary
+
+The changes ensure that the code is clean, adheres to best practices, and addresses the issues and hotspots identified by SonarQube. The unused imports were removed, and the HTTP methods were restricted to `GET` for better security.


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 13e120633e36a3cdc7fc98e3f8978628722ce05b

**Description:** This pull request addresses code cleanup and security improvements in the `LinksController.java` file. Unused imports were removed to improve readability and maintainability, and HTTP methods were explicitly restricted to `GET` to mitigate potential security risks associated with unsafe HTTP methods.

**Summary:**  
- **File Modified:** `src/main/java/com/scalesec/vulnado/LinksController.java`  
  - Removed unused imports: `org.springframework.boot.*`, `org.springframework.http.HttpStatus`, and `java.io.Serializable`.  
  - Updated `@RequestMapping` annotations to explicitly restrict HTTP methods to `GET` for `/links` and `/links-v2` endpoints.  
  - Improved code formatting for better readability.

**Recommendation:**  
1. **Code Quality:**  
   - Consider adding comments to explain why HTTP methods are restricted to `GET`. This will help future developers understand the rationale behind the change.  
   - Ensure that the `LinkLister.getLinks` and `LinkLister.getLinksV2` methods are properly validated to handle edge cases and prevent potential vulnerabilities like URL injection or malformed input.  

2. **Testing:**  
   - Test the `/links` and `/links-v2` endpoints to ensure they function correctly after restricting the HTTP methods.  
   - Verify that the removal of unused imports does not affect any dependent functionality.  

3. **Documentation:**  
   - Update any relevant documentation to reflect the changes in HTTP method restrictions for the endpoints.  

**Explanation of vulnerabilities:**  
1. **Unused Imports:**  
   - Unused imports can clutter the code and potentially introduce confusion or errors in the future. Removing them improves code clarity and reduces the risk of accidental misuse.  

2. **HTTP Method Restriction:**  
   - By default, `@RequestMapping` allows all HTTP methods, which can expose endpoints to unintended actions like `POST`, `PUT`, or `DELETE`. This could lead to vulnerabilities such as unauthorized data modification or deletion.  
   - Explicitly restricting the HTTP methods to `GET` ensures that the endpoints are only used for safe, read-only operations.  

**Suggested Code for Vulnerability Fix:**  
The vulnerability related to unrestricted HTTP methods was addressed by explicitly specifying the `method` parameter in the `@RequestMapping` annotations:  
```java
@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
```  
This change ensures that only `GET` requests are allowed, mitigating the risk of unsafe HTTP methods being used.

No additional vulnerabilities were identified in this pull request.