### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/CowController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CowController.java
+++ b/src/main/java/com/scalesec/vulnado/CowController.java
@@ -1,15 +1,59 @@
+To address the remarks from SonarQube, we will analyze and fix the issues one by one.
+
+---
+
+### **Remark Analysis and Fixes**
+#### **[6]:**
+- **[ISSUE](java:S1128):** Remove this unused import `java.io.Serializable`.
+- **Analysis:** The `java.io.Serializable` import is not used anywhere in the code. It should be removed to clean up the code and avoid unnecessary imports.
+
+@RequestMapping(value = "/cowsay", method = RequestMethod.GET)
+- **[HOTSPOT](java:S3752):** Make sure allowing safe and unsafe HTTP methods is safe here.
+- **Analysis:** The `@RequestMapping` annotation allows all HTTP methods (GET, POST, PUT, DELETE, etc.) by default. This can be a security risk if unsafe methods are not explicitly restricted. To address this, we should restrict the allowed HTTP methods to only those necessary for this endpoint. Since this endpoint is likely used to retrieve data, we will restrict it to `GET`.
+
+---
+
+### **ContentEditor Fixes**
+
+```json
+{
+  "operations": [
+    {
+      "operation": "DELETE",
+      "lineNumber": 6
+    },
+    {
+      "operation": "REPLACE",
+      "lineNumber": 11,
+      "content": "@RequestMapping(value = \"/cowsay\", method = RequestMethod.GET)"
+    }
+  ]
+}
+```
+
+---
+
+### **Explanation of Fixes**
+1. **Line 6:** The unused import `java.io.Serializable` is removed to clean up the code.
+2. **Line 11:** The `@RequestMapping` annotation is updated to restrict the allowed HTTP methods to `GET` by specifying `method = RequestMethod.GET`.
+
+---
+
+### **Updated Code**
+```java
 package com.scalesec.vulnado;
 
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 
-import java.io.Serializable;
-
 @RestController
 @EnableAutoConfiguration
 public class CowController {
-    @RequestMapping(value = "/cowsay")
+    @RequestMapping(value = "/cowsay", method = RequestMethod.GET)
     String cowsay(@RequestParam(defaultValue = "I love Linux!") String input) {
         return Cowsay.run(input);
     }
 }
+```
+
+This updated code addresses the SonarQube remarks and ensures the code is clean and secure.


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the ff1ba550448c47bacc5ac27d8da5eb3818b80e4a

**Description:** This pull request addresses two issues identified by SonarQube in the `CowController.java` file. The changes include removing an unused import and restricting the HTTP methods allowed for the `/cowsay` endpoint to improve code cleanliness and security.

**Summary:**  
- **File Modified:** `src/main/java/com/scalesec/vulnado/CowController.java`  
  - **Unused Import Removal:** The `java.io.Serializable` import was removed as it was not used anywhere in the code.  
  - **HTTP Method Restriction:** The `@RequestMapping` annotation for the `/cowsay` endpoint was updated to explicitly allow only the `GET` method, reducing the risk of unintended access via other HTTP methods.  

**Recommendation:**  
1. **Code Quality:** Removing unused imports is a good practice as it improves code readability and reduces potential confusion for future developers. Ensure that similar unused imports are identified and removed across the codebase.  
2. **Security:** Restricting HTTP methods is a critical step in securing endpoints. However, consider reviewing all endpoints in the application to ensure that only necessary HTTP methods are allowed for each.  
3. **Testing:** After making these changes, test the `/cowsay` endpoint thoroughly to ensure it functions correctly with the `GET` method and does not respond to other HTTP methods.  

**Explanation of vulnerabilities:**  
1. **Unused Import (`java.io.Serializable`):** While not a direct security vulnerability, unused imports can clutter the code and potentially lead to confusion or errors in the future. Removing it improves code hygiene.  
   - **Correction:** The line `import java.io.Serializable;` was deleted.  

2. **Unrestricted HTTP Methods:** Allowing all HTTP methods by default can expose the endpoint to unintended access or misuse. For example, allowing `POST` or `DELETE` methods could lead to unauthorized data modification or deletion.  
   - **Correction:** The `@RequestMapping` annotation was updated to explicitly allow only the `GET` method:  
     ```java
     @RequestMapping(value = "/cowsay", method = RequestMethod.GET)
     ```  
   - **Suggestion:** Review other endpoints in the application to ensure similar restrictions are applied where necessary. Additionally, consider using `@GetMapping` for better readability and alignment with modern Spring conventions.  

By implementing these changes, the code is now cleaner and more secure.