### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,23 +1,96 @@
+To address the remarks provided by SonarQube, we will analyze and fix each issue step by step. Below are the changes required:
+
+### [3]: Remove unused import `org.springframework.boot.*`
+The import `org.springframework.boot.*` is not used in the code and should be removed.
+
+
+### [4]: Remove unused import `org.springframework.http.HttpStatus`
+The import `org.springframework.http.HttpStatus` is not used in the code and should be removed.
+
+---
+
+@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
+The import `java.io.Serializable` is not used in the code and should be removed.
+
+---
+@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
+### [15] and [19]: Ensure safe handling of HTTP methods
+The remarks suggest verifying the safety of allowing both safe and unsafe HTTP methods. Since the code uses `@RequestMapping`, which allows all HTTP methods by default, we should restrict it to safe methods (e.g., `GET`) explicitly.
+
+---
+
+### ContentEditor Changes
+
+Here are the changes applied using the `ContentEditor`:
+
+```json
+{
+  "operations": [
+    {
+      "operation": "DELETE",
+      "lineNumber": 3
+    },
+    {
+      "operation": "DELETE",
+      "lineNumber": 4
+    },
+    {
+      "operation": "DELETE",
+      "lineNumber": 8
+    },
+    {
+      "operation": "REPLACE",
+      "lineNumber": 15,
+      "content": "@RequestMapping(value = \"/links\", produces = \"application/json\", method = RequestMethod.GET)"
+    },
+    {
+      "operation": "REPLACE",
+      "lineNumber": 19,
+      "content": "@RequestMapping(value = \"/links-v2\", produces = \"application/json\", method = RequestMethod.GET)"
+    }
+  ]
+}
+```
+
+---
+
+### Explanation of Changes
+
+1. **Unused Imports**:
+   - Removed the unused imports `org.springframework.boot.*`, `org.springframework.http.HttpStatus`, and `java.io.Serializable` to clean up the code and improve readability.
+
+2. **Restrict HTTP Methods**:
+   - Updated the `@RequestMapping` annotations on lines 15 and 19 to explicitly allow only the `GET` method. This ensures that unsafe HTTP methods (e.g., `POST`, `PUT`, `DELETE`) are not allowed, addressing the security hotspot.
+
+---
+
+### Final Code After Changes
+
+```java
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
+  List<String> links(@RequestParam String url) throws IOException {
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
+
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
+  List<String> linksV2(@RequestParam String url) throws BadRequest {
     return LinkLister.getLinksV2(url);
   }
 }
+```
+
+---
+
+### Summary
+
+The changes ensure that the code is clean, adheres to best practices, and addresses the issues and hotspots identified by SonarQube. The unused imports were removed, and the HTTP methods were restricted to `GET` for better security.


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 7c43b0f14b0bb06375e22b4f7fea6c9ce6661bd8

**Description:** This pull request addresses code quality and security concerns flagged by SonarQube in the `LinksController.java` file. The changes include removing unused imports to improve code readability and explicitly restricting HTTP methods to `GET` for enhanced security.

**Summary:**  
- **File Modified:** `src/main/java/com/scalesec/vulnado/LinksController.java`  
  - **Unused Imports Removed:**  
    - `org.springframework.boot.*`  
    - `org.springframework.http.HttpStatus`  
    - `java.io.Serializable`  
  - **HTTP Method Restriction:**  
    - Updated `@RequestMapping` annotations for `/links` and `/links-v2` endpoints to explicitly allow only the `GET` method. This prevents unsafe HTTP methods (e.g., `POST`, `PUT`, `DELETE`) from being used.  

**Recommendation:**  
1. **Code Quality:**  
   - Removing unused imports is a good practice as it improves readability and reduces potential confusion for developers. Ensure that future imports are only added when necessary.  
   - Consider using `@GetMapping` instead of `@RequestMapping` for endpoints that only handle `GET` requests. This is more concise and improves code clarity. Example:  
     ```java
     @GetMapping(value = "/links", produces = "application/json")
     List<String> links(@RequestParam String url) throws IOException {
         return LinkLister.getLinks(url);
     }
     ```  

2. **Testing:**  
   - Verify that the endpoints `/links` and `/links-v2` function correctly after restricting the HTTP methods. Ensure that requests using methods other than `GET` are properly rejected.  

3. **Documentation:**  
   - Update any API documentation to reflect the restriction of HTTP methods to `GET` for these endpoints. This ensures that consumers of the API are aware of the change.  

**Explanation of vulnerabilities:**  
1. **Unused Imports:**  
   - Unused imports do not pose a direct security risk but can clutter the code and potentially lead to confusion. Removing them is a good practice.  

2. **HTTP Method Restriction:**  
   - Allowing all HTTP methods by default can lead to security vulnerabilities, such as unintended data modification or deletion. By explicitly restricting the endpoints to `GET`, the risk of such vulnerabilities is mitigated.  

   **Before:**  
   ```java
   @RequestMapping(value = "/links", produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException {
       return LinkLister.getLinks(url);
   }
   ```  

   **After:**  
   ```java
   @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
   List<String> links(@RequestParam String url) throws IOException {
       return LinkLister.getLinks(url);
   }
   ```  

   **Suggestion:** Use `@GetMapping` for better readability and adherence to conventions.  

No additional vulnerabilities were identified in this pull request. The changes made are appropriate and address the flagged issues effectively.