### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -7,12 +7,14 @@ import org.jsoup.select.Elements;
 import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
+import java.util.logging.Logger;
 import java.net.*;
 
 
+  private LinkLister() {}
 public class LinkLister {
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +27,8 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      Logger logger = Logger.getLogger(LinkLister.class.getName());
+      logger.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 55d4d5b4a6406e46306d23055c2e44a7f6946dc8

**Description:** This pull request modifies the `LinkLister.java` file to improve code quality and security. Changes include the addition of a private constructor to prevent instantiation, the replacement of `System.out.println` with a `Logger` for better logging practices, and minor syntax improvements such as removing redundant type arguments in generics.

**Summary:**  
- **File Modified:** `src/main/java/com/scalesec/vulnado/LinkLister.java`  
  - **Added:** `Logger` for logging instead of `System.out.println`.  
  - **Added:** A private constructor to prevent instantiation of the `LinkLister` class.  
  - **Modified:** Removed redundant type arguments in the `ArrayList` instantiation (`new ArrayList<String>()` → `new ArrayList<>()`).  
  - **Improved:** Logging practices by replacing `System.out.println` with `Logger.info`.  

**Recommendation:**  
1. **Logging Configuration:** Ensure that the `Logger` is properly configured in the application to avoid excessive or unformatted logs. Consider using a logging framework like SLF4J with Logback for better flexibility and configuration.  
2. **Error Handling:** The `getLinksV2` method throws a `BadRequest` exception for private IPs, which is good for security. However, consider adding more detailed error messages or logging the exception for better debugging.  
3. **Unit Tests:** Add unit tests to verify the behavior of the `getLinks` and `getLinksV2` methods, especially for edge cases like invalid URLs or URLs with no links.  
4. **Input Validation:** Validate the `url` parameter before processing to ensure it is a valid URL format. This can prevent potential runtime errors.  

**Explanation of vulnerabilities:**  
1. **Private IP Check:** The code correctly prevents the use of private IPs by checking the host against common private IP ranges (`172.`, `192.168`, `10.`). This is a good security measure to prevent SSRF (Server-Side Request Forgery) attacks.  
   - **Suggestion:** Expand the private IP check to include other reserved IP ranges, such as `127.0.0.1` (localhost) and `0.0.0.0`.  
   - **Example Correction:**  
     ```java
     if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.") || host.equals("127.0.0.1") || host.equals("0.0.0.0")) {
         throw new BadRequest("Use of Private IP");
     }
     ```  
2. **Logging:** While replacing `System.out.println` with `Logger` is a good practice, ensure sensitive information (like URLs) is not logged in production environments to avoid leaking data.  

By addressing these recommendations, the code will be more robust, secure, and maintainable.