### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,19 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
 
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the fe83f0b18f212f641ac6bc4956465f9aa23fd7c1

**Description:** This pull request modifies the `LinksController.java` file in the `src/main/java/com/scalesec/vulnado` directory. The changes primarily involve adding explicit HTTP method definitions (`RequestMethod.GET`) to the `@RequestMapping` annotations for the `links` and `linksV2` endpoints. Additionally, unused imports have been removed from the file.

**Summary:**  
- **File Modified:** `src/main/java/com/scalesec/vulnado/LinksController.java`  
  - **Changes:**  
    - Added `method = RequestMethod.GET` to the `@RequestMapping` annotations for the `links` and `linksV2` endpoints. This explicitly defines the HTTP method for these endpoints, improving clarity and reducing ambiguity.  
    - Removed unused imports: `org.springframework.boot.*`, `org.springframework.http.HttpStatus`, and `java.io.Serializable`. This cleanup reduces clutter and improves code readability.  

**Recommendation:**  
1. **Code Quality:** The addition of explicit HTTP method definitions (`RequestMethod.GET`) is a good practice as it makes the code more readable and avoids ambiguity. However, consider using the more modern `@GetMapping` annotation instead of `@RequestMapping` for GET requests. This would make the code more concise and align with current Spring conventions. For example:  
   ```java
   @GetMapping(value = "/links", produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException {
       return LinkLister.getLinks(url);
   }
   ```
2. **Error Handling:** The `linksV2` method throws a `BadRequest` exception, but there is no indication of how this exception is handled. Ensure that proper exception handling mechanisms are in place, such as a global exception handler, to return meaningful error responses to the client.  
3. **Validation:** The `@RequestParam String url` parameter is not validated. Consider adding validation to ensure the `url` parameter is well-formed and secure. For example, you could use a library like Apache Commons Validator to check if the URL is valid.  

**Explanation of vulnerabilities:**  
1. **Potential Security Issue:** The `url` parameter is directly passed to the `LinkLister.getLinks` and `LinkLister.getLinksV2` methods without validation. This could lead to vulnerabilities such as Server-Side Request Forgery (SSRF) if the `LinkLister` methods make HTTP requests based on the input URL. To mitigate this, validate the `url` parameter to ensure it only allows safe and expected values. For example:  
   ```java
   if (!UrlValidator.getInstance().isValid(url)) {
       throw new BadRequest("Invalid URL format");
   }
   ```
2. **Error Handling:** The `BadRequest` exception thrown by the `linksV2` method is not handled within the controller. If this exception is not mapped to a proper HTTP response, it could result in a generic server error (500 Internal Server Error) being returned to the client. Implement a global exception handler to map exceptions to appropriate HTTP status codes and error messages.  

By addressing these recommendations and vulnerabilities, the code can be made more secure, maintainable, and aligned with best practices.