### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/CowController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CowController.java
+++ b/src/main/java/com/scalesec/vulnado/CowController.java
@@ -3,12 +3,11 @@ package com.scalesec.vulnado;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 
-import java.io.Serializable;
 
 @RestController
 @EnableAutoConfiguration
 public class CowController {
-    @RequestMapping(value = "/cowsay")
+    @GetMapping(value = "/cowsay")
     String cowsay(@RequestParam(defaultValue = "I love Linux!") String input) {
         return Cowsay.run(input);
     }


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 95ee16b4af0d3867bf43cb57ebc2e4dc0fca91db

**Description:** The pull request updates the `CowController.java` file by modifying the request mapping annotation and removing an unused import statement. The change enhances the clarity and efficiency of the code.

**Summary:** 
- **File Modified:** `src/main/java/com/scalesec/vulnado/CowController.java`
  - **Changes Made:**
    - Removed the import statement for `java.io.Serializable`, which was not being used in the class.
    - Changed the annotation from `@RequestMapping` to `@GetMapping` for the `/cowsay` endpoint. This change specifies that the endpoint should handle HTTP GET requests, which is more precise than the generic `@RequestMapping`.

**Recommendation:** 
- Ensure that all import statements are necessary and used within the class to maintain clean and efficient code.
- Verify that the change from `@RequestMapping` to `@GetMapping` aligns with the intended functionality of the endpoint, as this change restricts the endpoint to only handle GET requests. If other HTTP methods are required, consider using `@RequestMapping` with method attributes.

**Explanation of vulnerabilities:** 
- No specific vulnerabilities were addressed in this pull request. However, it is important to validate the `input` parameter to prevent potential security issues such as injection attacks. Consider implementing input validation or sanitization to ensure that the `input` parameter does not contain malicious content. For example:

```java
String sanitizedInput = sanitizeInput(input);
return Cowsay.run(sanitizedInput);

private String sanitizeInput(String input) {
    // Implement sanitization logic here
    return input.replaceAll("[^a-zA-Z0-9 ]", "");
}
```

This suggestion helps prevent potential security vulnerabilities by ensuring that only safe characters are processed by the `Cowsay.run` method.