### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -1,5 +1,6 @@
 package com.scalesec.vulnado;
 
+import java.util.logging.Logger;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -10,9 +11,10 @@ import java.io.IOException;
 import java.net.*;
 
 
+private LinkLister() {}
 public class LinkLister {
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +27,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      logger.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the a89b1a2f5919df7571983307be2473d3fe8db23d

**Description:** The pull request introduces several modifications to the `LinkLister.java` file. These changes include the addition of a logging mechanism, a private constructor to prevent instantiation, and minor code improvements for better readability and performance.

**Summary:** 
- **File Modified:** `src/main/java/com/scalesec/vulnado/LinkLister.java`
  - **Logger Addition:** Introduced `java.util.logging.Logger` for logging purposes, replacing `System.out.println` with `logger.info` for better logging practices.
  - **Private Constructor:** Added a private constructor `private LinkLister() {}` to prevent instantiation of the `LinkLister` class, which is a common practice for utility classes.
  - **Diamond Operator Usage:** Simplified the instantiation of `ArrayList` using the diamond operator (`<>`) for type inference, enhancing readability and reducing verbosity.

**Recommendation:** 
- Ensure that the logger is properly configured to handle different logging levels and outputs. Consider setting up a logging configuration file or using a logging framework like SLF4J for more advanced logging capabilities.
- Review the usage of the private constructor to confirm that the class is intended to be a utility class and should not be instantiated.
- Consider adding unit tests to verify the functionality of the `getLinks` and `getLinksV2` methods, especially focusing on edge cases and error handling.

**Explanation of vulnerabilities:** 
- **Logging Sensitive Information:** The change from `System.out.println` to `logger.info` is a positive step towards better logging practices. However, ensure that sensitive information is not logged inadvertently, especially if the logger configuration outputs to a file or external system.
- **URL Validation:** The current implementation checks for private IP addresses and throws a `BadRequest` exception. While this is a good practice, consider expanding the validation to include other potentially harmful inputs, such as malformed URLs or URLs pointing to known malicious domains.